### PR TITLE
Fixing typo with Auth interface call

### DIFF
--- a/src/PHPixie/DefaultBundle.php
+++ b/src/PHPixie/DefaultBundle.php
@@ -8,7 +8,7 @@ abstract class DefaultBundle implements Provides\HTTPProcessor,
     Provides\ORM,
     Provides\RouteResolver,
     Provides\TemplateLocator,
-    Provides\AuthRepositories,
+    Provides\Auth,
     Provides\WebRoot
 {
     protected $builder;


### PR DESCRIPTION
fixing implementation of Auth interface. should be "Provides\Auth" instead of "Provides\AuthRepositories"
